### PR TITLE
Missing Directory Reference in Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then, you can run the demo by following these steps:
 1. Install Python 3.11 or higher
 2. `pip install modal`
 3. `modal setup`
-4. `modal serve .\main.py`
+4. `modal serve \main.py`
 
 # How to use the demo from the provided API?
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from modal import Mount, Secret, asgi_app, Image
 from vrag.app import app
 from vrag.colpali import ColPaliModel
 
-static_path = Path(__file__).with_name("frontend").resolve()
+static_path = Path(__file__).with_name("frontend").joinpath('dist').resolve()
 
 img = (
     Image.debian_slim(python_version="3.11")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from modal import Mount, Secret, asgi_app, Image
 from vrag.app import app
 from vrag.colpali import ColPaliModel
 
-static_path = Path(__file__).with_name("frontend").joinpath("dist").resolve()
+static_path = Path(__file__).with_name("frontend").resolve()
 
 img = (
     Image.debian_slim(python_version="3.11")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from modal import Mount, Secret, asgi_app, Image
 from vrag.app import app
 from vrag.colpali import ColPaliModel
 
-static_path = Path(__file__).with_name("frontend").joinpath('dist').resolve()
+static_path = Path(__file__).with_name("frontend").joinpath("dist").resolve()
 
 img = (
     Image.debian_slim(python_version="3.11")


### PR DESCRIPTION
Directory refers to a folder not found.  Running `modal serve \main.py` returns the following:
`Stopping app - uncaught exception raised locally: FileNotFoundError(PosixPath('/Users/.../vision-is-all-you-need/frontend/dist')).`

Removing this allows the completion and resolution of this execution.